### PR TITLE
feat(`CI`): enable Github CI workflow on Windows-MSVC, MacOS and Ubuntu

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,0 +1,73 @@
+name: Build
+
+on:
+    push:
+    pull_request:
+
+permissions: write-all
+
+jobs:
+    build:
+        name: Build ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [windows-latest, ubuntu-latest, macos-latest]
+                include:
+                  - os: windows-latest
+                    configurePreset: Release-Windows
+                    buildPreset: Release-Windows
+                    arch: win64_msvc2022_64
+                  - os: ubuntu-latest
+                    configurePreset: Release-Unix
+                    buildPreset: Release-Unix
+                    arch: linux_gcc_64
+                  - os: macos-latest
+                    configurePreset: Release-Unix
+                    buildPreset: Release-Unix
+                    arch: clang_64
+
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v4
+            with:
+                submodules: 'recursive'
+
+          - name: Install dependencies
+            shell: pwsh
+            run: |
+                if (Get-Command apt-get -ErrorAction SilentlyContinue) {
+                $deps = 'autoconf', 'automake', 'autoconf-archive', '^libxcb.*-dev',
+                    'libx11-xcb-dev', 'libxrender-dev', 'libxi-dev',
+                    'libxkbcommon-dev', 'libxkbcommon-x11-dev',
+                    'libglu1-mesa-dev', 'libegl1-mesa-dev'
+                sudo apt update
+                sudo apt install -y @deps
+                } elseif (Get-Command brew -ErrorAction SilentlyContinue) {
+                $deps = 'autoconf', 'automake', 'autoconf-archive', 'libtool'
+                brew install @deps
+                }
+
+          - name: Install CMake
+            uses: lukka/get-cmake@latest
+
+          - name: Install Ninja
+            uses: ashutoshvarma/setup-ninja@v1.1
+
+          - name: Install Qt
+            uses: jurplel/install-qt-action@v4
+            with:
+                arch: ${{ matrix.arch }}
+
+          - name: Install vcpkg
+            uses: lukka/run-vcpkg@v11
+            with:
+                vcpkgJsonGlob: 'vcpkg.json'
+                vcpkgConfigurationJsonGlob: 'vcpkg-configuration.json'
+
+          - name: Build
+            uses: lukka/run-cmake@v10
+            with:
+                configurePreset: ${{ matrix.configurePreset }}
+                buildPreset: ${{ matrix.buildPreset }}


### PR DESCRIPTION
介于我们项目的`CMakePresets.json`暂时没有支持除`MSVC`和`Ninja`之外的编译器，所以暂时只完成`Windows-MSVC`、`MacOS`和主流Linux发行版(基于`Ubuntu`)的CI支持。
https://github.com/NJUPT-SAST-CXX/sast-readium/issues/5#issuecomment-3196443829