### PR TITLE
Fix(CMakeLists.txt): remove vcpkg toolchain file path from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.28)
-set(CMAKE_TOOLCHAIN_FILE $ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
 project(sast-readium LANGUAGES CXX VERSION 0.1.0.0)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
CMakePresets.json已经设置了相应的缓存变量，应该就没必要再在CMakeLists.txt里写一遍；
主要是加了这一句，我这边CMakeSystem.cmake会因为转义字符导致路径出问题 :(